### PR TITLE
Add browser-based voxel camp explorer prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Guidelines
+
+- Prefer clear, commented ES module code under `src/` with descriptive function and class names.
+- Keep dependencies minimal; rely on CDNs for browser libraries instead of adding build steps.
+- Favor readability over micro-optimizations; keep functions under ~60 lines when possible.
+- Update documentation (`README.md`) whenever you add or change features in the web game.
+- Keep UI text concise and friendly.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# simple-shorts
+# Voxel Camp Explorer
+
+A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
+
+## Features
+- Procedural terrain seeded per session, with the active seed shown in the corner.
+- Simple third-person character with WASD + drag-to-look controls; touch joystick and tap-to-collect for mobile.
+- Sparse resources near camp to encourage exploration, plus a compass hint toward the nearest needed cache.
+- Lightweight assets (no build step); served via a single `index.html` + ES modules.
+
+## Getting Started
+1. Start a simple server so the modules load correctly:
+   ```bash
+   npx http-server .
+   ```
+   or use any static server you prefer.
+2. Open `http://localhost:8080` (or your chosen port) in a modern browser.
+
+## Controls
+- **Desktop:** WASD/arrow keys to move, drag the mouse to rotate, **E** to collect nearby resources.
+- **Mobile:** On-screen joystick to move, drag/right side to look, tap the **Collect** button or simply tap near a resource when close.
+
+## Project Layout
+- `index.html` – Canvas, HUD, mobile controls.
+- `src/main.js` – Game bootstrap and loop.
+- `src/world.js` – Terrain generation, camp, and seeding.
+- `src/player.js` – Third-person controller and camera follow.
+- `src/resources.js` – Resource nodes, collection logic, and compass hinting.
+- `src/input.js` – Keyboard/mouse/touch input handling.
+- `src/ui.js` – HUD updates and win screen.
+
+## Notes
+- Each reload generates a new seed; copy the seed in the lower-right corner if you want to replay the same layout.
+- Performance is tuned for simplicity—no build steps or heavy dependencies. If you need more polish later, you can swap meshes for higher-detail models without changing the core loop.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Voxel Camp Explorer</title>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; overflow: hidden; font-family: 'Inter', system-ui, -apple-system, sans-serif; background: #0e0f12; color: #f4f5f7; }
+    canvas { display: block; }
+    #ui {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 12px;
+    }
+    #hud {
+      display: flex;
+      gap: 10px;
+      font-size: 14px;
+      padding: 6px 10px;
+      background: rgba(0,0,0,0.35);
+      border-radius: 8px;
+      width: fit-content;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.08);
+    }
+    .legend { opacity: 0.8; font-size: 13px; }
+    #seed {
+      position: absolute;
+      right: 8px;
+      bottom: 8px;
+      font-size: 11px;
+      opacity: 0.75;
+      background: rgba(0,0,0,0.35);
+      padding: 4px 6px;
+      border-radius: 4px;
+      pointer-events: none;
+    }
+    #message {
+      align-self: center;
+      margin-top: 20px;
+      padding: 10px 14px;
+      background: rgba(0,0,0,0.55);
+      border: 1px solid rgba(255,255,255,0.12);
+      border-radius: 10px;
+      text-align: center;
+      min-width: 220px;
+      pointer-events: none;
+    }
+    #win {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      padding: 16px 20px;
+      border-radius: 12px;
+      background: rgba(0, 0, 0, 0.7);
+      border: 1px solid rgba(255,255,255,0.18);
+      text-align: center;
+      display: none;
+    }
+    #win button {
+      margin-top: 10px;
+      padding: 8px 14px;
+      border-radius: 8px;
+      border: none;
+      background: #3ecf8e;
+      color: #0b141a;
+      font-weight: 600;
+      cursor: pointer;
+      pointer-events: auto;
+    }
+    #joystick {
+      position: absolute;
+      left: 20px;
+      bottom: 20px;
+      width: 120px;
+      height: 120px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: none;
+      pointer-events: auto;
+      touch-action: none;
+    }
+    #joystick .knob {
+      position: absolute;
+      width: 60px;
+      height: 60px;
+      left: 30px;
+      top: 30px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.18);
+      transform: translate(0,0);
+    }
+    #interact-btn {
+      position: absolute;
+      right: 24px;
+      bottom: 36px;
+      padding: 12px 16px;
+      border-radius: 12px;
+      background: rgba(255,255,255,0.18);
+      color: #0b141a;
+      font-weight: 700;
+      border: none;
+      display: none;
+      pointer-events: auto;
+      touch-action: manipulation;
+    }
+    @media (max-width: 900px) {
+      #joystick, #interact-btn { display: block; }
+      #hud { font-size: 13px; }
+    }
+  </style>
+</head>
+<body>
+  <div id="ui">
+    <div id="hud">
+      <div class="pill">🌲 Wood: <span id="wood-count">0</span>/10</div>
+      <div class="pill">🪨 Stone: <span id="stone-count">0</span>/10</div>
+      <div class="pill">🌽 Corn: <span id="corn-count">0</span>/10</div>
+      <div class="pill legend">WASD/drag to move + look, E/tap to collect</div>
+    </div>
+    <div id="message">Collect 10 wood, 10 stone, and 10 corn. Explore outward for more resources.</div>
+  </div>
+  <div id="seed"></div>
+  <div id="win">
+    <h2>All gathered!</h2>
+    <p>You collected everything. Nice exploring.</p>
+    <button id="restart">Restart</button>
+  </div>
+  <div id="joystick"><div class="knob"></div></div>
+  <button id="interact-btn">Collect</button>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/input.js
+++ b/src/input.js
@@ -1,0 +1,126 @@
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+
+export class Input {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.keys = new Set();
+    this.lookDelta = new THREE.Vector2();
+    this.moveVector = new THREE.Vector3();
+    this.interactQueued = false;
+    this.dragging = false;
+    this.lastPointer = null;
+
+    this.joystick = document.getElementById('joystick');
+    this.knob = this.joystick.querySelector('.knob');
+    this.interactButton = document.getElementById('interact-btn');
+    this.isMobile = window.matchMedia('(max-width: 900px)').matches;
+
+    this.bindEvents();
+  }
+
+  bindEvents() {
+    window.addEventListener('keydown', (e) => {
+      const key = e.key.toLowerCase();
+      this.keys.add(key);
+      if (key === 'e') this.queueInteract();
+    });
+    window.addEventListener('keyup', (e) => this.keys.delete(e.key.toLowerCase()));
+    window.addEventListener('mousedown', (e) => this.startDrag(e));
+    window.addEventListener('mousemove', (e) => this.onDrag(e));
+    window.addEventListener('mouseup', () => this.stopDrag());
+    window.addEventListener('touchstart', (e) => this.handleTouchStart(e), { passive: false });
+    window.addEventListener('touchmove', (e) => this.handleTouchMove(e), { passive: false });
+    window.addEventListener('touchend', () => this.handleTouchEnd());
+
+    this.interactButton.addEventListener('click', () => this.queueInteract());
+  }
+
+  startDrag(event) {
+    if (event.target === this.interactButton) return;
+    this.dragging = true;
+    this.lastPointer = new THREE.Vector2(event.clientX, event.clientY);
+  }
+
+  onDrag(event) {
+    if (!this.dragging) return;
+    const current = new THREE.Vector2(event.clientX, event.clientY);
+    const delta = current.clone().sub(this.lastPointer);
+    this.lookDelta.add(delta);
+    this.lastPointer = current;
+  }
+
+  stopDrag() {
+    this.dragging = false;
+    this.lastPointer = null;
+  }
+
+  handleTouchStart(event) {
+    if (!this.isMobile) return;
+    const touch = event.touches[0];
+    if (!touch) return;
+    const rect = this.joystick.getBoundingClientRect();
+    if (touch.clientX < window.innerWidth * 0.55) {
+      this.touchOrigin = new THREE.Vector2(touch.clientX, touch.clientY);
+      this.joystick.style.display = 'block';
+      this.joystick.style.left = `${this.touchOrigin.x - rect.width / 2}px`;
+      this.joystick.style.top = `${this.touchOrigin.y - rect.height / 2}px`;
+    } else {
+      this.dragging = true;
+      this.lastPointer = new THREE.Vector2(touch.clientX, touch.clientY);
+    }
+  }
+
+  handleTouchMove(event) {
+    if (!this.isMobile) return;
+    const touch = event.touches[0];
+    if (!touch || !this.touchOrigin) return;
+    event.preventDefault();
+    const current = new THREE.Vector2(touch.clientX, touch.clientY);
+    const delta = current.clone().sub(this.touchOrigin);
+    const maxDist = 40;
+    const clamped = delta.clone().clampLength(0, maxDist);
+    this.knob.style.transform = `translate(${clamped.x}px, ${clamped.y}px)`;
+    this.moveVector.set(clamped.x / maxDist, 0, -clamped.y / maxDist);
+  }
+
+  handleTouchEnd() {
+    if (!this.isMobile) return;
+    this.moveVector.set(0, 0, 0);
+    this.touchOrigin = null;
+    this.knob.style.transform = 'translate(0px, 0px)';
+    this.joystick.style.display = 'block';
+    this.stopDrag();
+  }
+
+  queueInteract() {
+    this.interactQueued = true;
+  }
+
+  consumeInteract() {
+    if (this.interactQueued) {
+      this.interactQueued = false;
+      return true;
+    }
+    return false;
+  }
+
+  getMoveVector() {
+    const dir = new THREE.Vector3();
+    if (this.keys.has('w') || this.keys.has('arrowup')) dir.z -= 1;
+    if (this.keys.has('s') || this.keys.has('arrowdown')) dir.z += 1;
+    if (this.keys.has('a') || this.keys.has('arrowleft')) dir.x -= 1;
+    if (this.keys.has('d') || this.keys.has('arrowright')) dir.x += 1;
+
+    if (dir.lengthSq() === 0 && this.moveVector.lengthSq() > 0) {
+      dir.copy(this.moveVector);
+    }
+
+    return dir;
+  }
+
+  getLookDelta() {
+    const delta = this.lookDelta.clone();
+    this.lookDelta.set(0, 0);
+    return delta;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,111 @@
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+import { World } from './world.js';
+import { Player } from './player.js';
+import { Input } from './input.js';
+import { ResourceManager } from './resources.js';
+import { UIOverlay } from './ui.js';
+
+const canvasContainer = document.body;
+
+function createRenderer() {
+  const renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.shadowMap.enabled = true;
+  canvasContainer.appendChild(renderer.domElement);
+  return renderer;
+}
+
+function createScene() {
+  const scene = new THREE.Scene();
+  scene.background = new THREE.Color('#a8d7ff');
+  scene.fog = new THREE.FogExp2('#a8d7ff', 0.012);
+  return scene;
+}
+
+function createLights(scene) {
+  const ambient = new THREE.HemisphereLight('#e4efff', '#4d5666', 0.9);
+  scene.add(ambient);
+
+  const sun = new THREE.DirectionalLight('#ffffff', 1.1);
+  sun.position.set(40, 60, 25);
+  sun.castShadow = true;
+  const d = 60;
+  sun.shadow.camera.left = -d;
+  sun.shadow.camera.right = d;
+  sun.shadow.camera.top = d;
+  sun.shadow.camera.bottom = -d;
+  scene.add(sun);
+}
+
+function randomSeed() {
+  const bytes = crypto.getRandomValues(new Uint32Array(2));
+  return `${bytes[0].toString(16)}-${bytes[1].toString(16)}`;
+}
+
+class Game {
+  constructor() {
+    this.seed = randomSeed();
+    this.scene = createScene();
+    this.renderer = createRenderer();
+    this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 500);
+    this.world = new World(this.seed);
+    this.input = new Input(this.renderer.domElement);
+    this.player = new Player(this.world, this.input);
+    this.resources = new ResourceManager(this.world, this.scene);
+    this.ui = new UIOverlay({
+      seed: this.seed,
+      onRestart: () => this.restart(),
+    });
+
+    this.scene.add(this.world.mesh);
+    this.scene.add(this.world.campGroup);
+    this.scene.add(this.player.mesh);
+    this.world.placeResources(this.resources);
+    this.resources.addToScene(this.scene);
+
+    createLights(this.scene);
+    this.lastTime = performance.now();
+    window.addEventListener('resize', () => this.onResize());
+    this.animate = this.animate.bind(this);
+    requestAnimationFrame(this.animate);
+  }
+
+  restart() {
+    window.location.reload();
+  }
+
+  onResize() {
+    this.camera.aspect = window.innerWidth / window.innerHeight;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+  }
+
+  update(delta) {
+    this.player.update(delta, this.camera);
+    const collected = this.resources.tryCollect(this.player, this.input.consumeInteract());
+    if (collected) {
+      this.ui.updateCounts(this.resources.counters);
+      this.resources.updateCompass(this.player.position, this.ui);
+      if (this.resources.hasWon()) {
+        this.ui.showWin();
+      }
+    } else {
+      this.resources.updateCompass(this.player.position, this.ui);
+    }
+    this.world.updateCampFire(delta);
+  }
+
+  animate() {
+    const now = performance.now();
+    const delta = (now - this.lastTime) / 1000;
+    this.lastTime = now;
+    this.update(delta);
+    this.renderer.render(this.scene, this.camera);
+    requestAnimationFrame(this.animate);
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  new Game();
+});

--- a/src/player.js
+++ b/src/player.js
@@ -1,0 +1,69 @@
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+
+
+export class Player {
+  constructor(world, input) {
+    this.world = world;
+    this.input = input;
+    this.position = new THREE.Vector3(0, world.getHeight(0, 0) + 2.6, 0);
+    this.velocity = new THREE.Vector3();
+    this.speed = 16;
+    this.turnSpeed = 0.08;
+    this.yaw = 0;
+    this.pitch = -0.35;
+    this.targetCameraOffset = new THREE.Vector3(0, 4.2, 8);
+
+    const bodyGeo = new THREE.CapsuleGeometry(0.7, 1.4, 4, 8);
+    const bodyMat = new THREE.MeshStandardMaterial({ color: '#f6e8c3', flatShading: true });
+    this.mesh = new THREE.Mesh(bodyGeo, bodyMat);
+    this.mesh.castShadow = true;
+    this.mesh.receiveShadow = true;
+    this.mesh.position.copy(this.position);
+  }
+
+  update(delta, camera) {
+    this.handleRotation(delta);
+    this.handleMovement(delta);
+    this.applyGroundSnap();
+    this.mesh.position.copy(this.position);
+    this.updateCamera(camera, delta);
+  }
+
+  handleRotation(delta) {
+    const look = this.input.getLookDelta();
+    this.yaw -= look.x * 0.003;
+    this.pitch -= look.y * 0.003;
+    this.pitch = Math.min(Math.max(this.pitch, -1.1), 0.2);
+    this.mesh.rotation.y = this.yaw + Math.PI;
+  }
+
+  handleMovement(delta) {
+    const dir = this.input.getMoveVector();
+    if (dir.lengthSq() > 0) {
+      dir.normalize();
+      const rotDir = new THREE.Vector3();
+      rotDir.x = dir.x * Math.cos(this.yaw) - dir.z * Math.sin(this.yaw);
+      rotDir.z = dir.x * Math.sin(this.yaw) + dir.z * Math.cos(this.yaw);
+      rotDir.y = 0;
+      this.velocity.copy(rotDir).multiplyScalar(this.speed * delta);
+      this.position.add(this.velocity);
+    } else {
+      this.velocity.setScalar(0);
+    }
+  }
+
+  applyGroundSnap() {
+    const groundY = this.world.getHeight(this.position.x, this.position.z);
+    const targetY = groundY + 2.4;
+    this.position.y = THREE.MathUtils.lerp(this.position.y, targetY, 0.2);
+  }
+
+  updateCamera(camera, delta) {
+    const offset = this.targetCameraOffset.clone();
+    const rot = new THREE.Euler(this.pitch, this.yaw, 0, 'YXZ');
+    offset.applyEuler(rot);
+    const desiredPos = this.position.clone().add(offset);
+    camera.position.lerp(desiredPos, 1 - Math.pow(0.001, delta));
+    camera.lookAt(this.position.clone().add(new THREE.Vector3(0, 1, 0)));
+  }
+}

--- a/src/resources.js
+++ b/src/resources.js
@@ -1,0 +1,122 @@
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+
+const RESOURCE_COLORS = {
+  wood: '#6f4c32',
+  stone: '#9da4b5',
+  corn: '#f8e36b',
+};
+
+const TARGET = 10;
+
+export class ResourceManager {
+  constructor(world, scene) {
+    this.world = world;
+    this.scene = scene;
+    this.nodes = [];
+    this.counters = { wood: 0, stone: 0, corn: 0 };
+    this.compassTarget = null;
+  }
+
+  spawnResource(type, position) {
+    const mesh = this.buildMesh(type);
+    mesh.position.copy(position);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    mesh.userData.type = type;
+    this.nodes.push(mesh);
+  }
+
+  buildMesh(type) {
+    if (type === 'wood') {
+      const geo = new THREE.CylinderGeometry(0.5, 0.6, 2.2, 6);
+      return new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color: RESOURCE_COLORS[type], flatShading: true }));
+    }
+    if (type === 'stone') {
+      const geo = new THREE.DodecahedronGeometry(0.9, 0);
+      return new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color: RESOURCE_COLORS[type], flatShading: true }));
+    }
+    const geo = new THREE.ConeGeometry(0.6, 1.6, 6);
+    const mesh = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color: RESOURCE_COLORS[type], flatShading: true }));
+    mesh.rotation.x = Math.PI;
+    return mesh;
+  }
+
+  addToScene(scene) {
+    this.nodes.forEach((mesh) => scene.add(mesh));
+  }
+
+  tryCollect(player, interacted) {
+    if (!interacted && !this.autoCollectTouch(player)) return false;
+    const node = this.findClosestWithin(player.position, 2.4);
+    if (!node) return false;
+    const type = node.userData.type;
+    this.counters[type] += 1;
+    node.visible = false;
+    this.nodes = this.nodes.filter((n) => n !== node);
+    this.scene.remove(node);
+    return true;
+  }
+
+  autoCollectTouch(player) {
+    // Allow tap-to-collect on mobile when close enough
+    const node = this.findClosestWithin(player.position, 1.8);
+    if (node && this.world && window.matchMedia('(max-width: 900px)').matches) {
+      return true;
+    }
+    return false;
+  }
+
+  findClosestWithin(origin, maxDistance) {
+    let closest = null;
+    let bestDist = maxDistance;
+    this.nodes.forEach((node) => {
+      const dist = origin.distanceTo(node.position);
+      if (dist <= bestDist) {
+        bestDist = dist;
+        closest = node;
+      }
+    });
+    return closest;
+  }
+
+  updateCompass(playerPos, ui) {
+    if (this.hasWon()) {
+      ui.setCompass('All done!');
+      return;
+    }
+    let target = this.compassTarget;
+    if (!target || !this.nodes.includes(target)) {
+      target = this.findNearestNeeded(playerPos);
+      this.compassTarget = target;
+    }
+    if (!target) {
+      ui.setCompass('Explore to find resources');
+      return;
+    }
+    const dir = target.position.clone().sub(playerPos);
+    const distance = dir.length();
+    dir.normalize();
+    const angle = Math.atan2(dir.x, dir.z);
+    const degrees = THREE.MathUtils.radToDeg(angle);
+    ui.setCompass(`Nearest cache: ${distance.toFixed(1)}m at ${degrees.toFixed(0)}°`);
+  }
+
+  findNearestNeeded(playerPos) {
+    const missingTypes = ['wood', 'stone', 'corn'].filter((t) => this.counters[t] < TARGET);
+    let closest = null;
+    let best = Infinity;
+    this.nodes.forEach((node) => {
+      if (!missingTypes.includes(node.userData.type)) return;
+      const d = playerPos.distanceTo(node.position);
+      if (d < best) {
+        best = d;
+        closest = node;
+      }
+    });
+    return closest;
+  }
+
+  hasWon() {
+    return this.counters.wood >= TARGET && this.counters.stone >= TARGET && this.counters.corn >= TARGET;
+  }
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -1,0 +1,29 @@
+export class UIOverlay {
+  constructor({ seed, onRestart }) {
+    this.seedEl = document.getElementById('seed');
+    this.woodEl = document.getElementById('wood-count');
+    this.stoneEl = document.getElementById('stone-count');
+    this.cornEl = document.getElementById('corn-count');
+    this.messageEl = document.getElementById('message');
+    this.winEl = document.getElementById('win');
+    this.restartBtn = document.getElementById('restart');
+    this.seedEl.textContent = `Seed: ${seed}`;
+    this.restartBtn.addEventListener('click', onRestart);
+    this.compassText = 'Explore to find resources';
+  }
+
+  updateCounts(counters) {
+    this.woodEl.textContent = counters.wood;
+    this.stoneEl.textContent = counters.stone;
+    this.cornEl.textContent = counters.corn;
+  }
+
+  setCompass(text) {
+    this.compassText = text;
+    this.messageEl.textContent = text;
+  }
+
+  showWin() {
+    this.winEl.style.display = 'block';
+  }
+}

--- a/src/world.js
+++ b/src/world.js
@@ -1,0 +1,159 @@
+import * as THREE from 'https://unpkg.com/three@0.161.0/build/three.module.js';
+
+function mulberry32(a) {
+  return function () {
+    a |= 0; a = a + 0x6D2B79F5 | 0;
+    let t = Math.imul(a ^ a >>> 15, 1 | a);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(str) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < str.length; i += 1) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export class World {
+  constructor(seed) {
+    this.seed = seed;
+    this.worldSize = 140;
+    this.gridResolution = 96;
+    this.heightMap = [];
+    this.heightScale = 6;
+    this.noiseScale = 14;
+    this.rng = mulberry32(hashString(seed));
+    this.mesh = this.buildTerrain();
+    this.campGroup = this.buildCamp();
+  }
+
+  noise(x, z) {
+    const scaledX = x / this.noiseScale;
+    const scaledZ = z / this.noiseScale;
+    const xi = Math.floor(scaledX);
+    const zi = Math.floor(scaledZ);
+    const xf = scaledX - xi;
+    const zf = scaledZ - zi;
+
+    const v00 = this.valueAt(xi, zi);
+    const v10 = this.valueAt(xi + 1, zi);
+    const v01 = this.valueAt(xi, zi + 1);
+    const v11 = this.valueAt(xi + 1, zi + 1);
+
+    const x1 = lerp(v00, v10, xf);
+    const x2 = lerp(v01, v11, xf);
+    return lerp(x1, x2, zf);
+  }
+
+  valueAt(x, z) {
+    const h = hashString(`${x},${z},${this.seed}`);
+    const rand = mulberry32(h);
+    return rand();
+  }
+
+  getHeight(x, z) {
+    const base = this.noise(x + 50, z + 50) * this.heightScale;
+    const detail = this.noise(x * 2.5 + 100, z * 2.5 + 100) * 1.5;
+    return base + detail;
+  }
+
+  buildTerrain() {
+    const size = this.worldSize;
+    const segments = this.gridResolution;
+    const geometry = new THREE.PlaneGeometry(size, size, segments, segments);
+    geometry.rotateX(-Math.PI / 2);
+
+    const positions = geometry.attributes.position;
+    for (let i = 0; i < positions.count; i += 1) {
+      const x = positions.getX(i);
+      const z = positions.getZ(i);
+      const y = this.getHeight(x, z);
+      positions.setY(i, y);
+    }
+    geometry.computeVertexNormals();
+
+    const material = new THREE.MeshLambertMaterial({ color: '#6dbb65', flatShading: true });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.receiveShadow = true;
+    mesh.name = 'terrain';
+    return mesh;
+  }
+
+  buildCamp() {
+    const group = new THREE.Group();
+
+    const padGeometry = new THREE.CylinderGeometry(3, 3, 0.6, 6);
+    const padMaterial = new THREE.MeshLambertMaterial({ color: '#cfc2a2', flatShading: true });
+    const pad = new THREE.Mesh(padGeometry, padMaterial);
+    pad.position.set(0, this.getHeight(0, 0) + 0.3, 0);
+    pad.receiveShadow = true;
+    group.add(pad);
+
+    const tent = new THREE.Mesh(
+      new THREE.ConeGeometry(2, 3, 4),
+      new THREE.MeshLambertMaterial({ color: '#f2f5f7', flatShading: true })
+    );
+    tent.position.set(-1.2, pad.position.y + 1.5, 0.4);
+    tent.castShadow = true;
+    group.add(tent);
+
+    const fireBase = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.8, 1.2, 0.4, 5),
+      new THREE.MeshLambertMaterial({ color: '#6b4b3e', flatShading: true })
+    );
+    fireBase.position.set(1.6, pad.position.y + 0.2, -1);
+    fireBase.castShadow = true;
+    fireBase.receiveShadow = true;
+    group.add(fireBase);
+
+    const flameGeo = new THREE.SphereGeometry(0.6, 6, 6);
+    const flameMat = new THREE.MeshBasicMaterial({ color: '#ffb347' });
+    this.flame = new THREE.Mesh(flameGeo, flameMat);
+    this.flame.position.set(1.6, pad.position.y + 0.9, -1);
+    group.add(this.flame);
+
+    group.name = 'camp';
+    return group;
+  }
+
+  updateCampFire(delta) {
+    if (!this.flame) return;
+    this.flame.scale.setScalar(1 + Math.sin(performance.now() * 0.006) * 0.08);
+    this.flame.position.y += Math.sin(performance.now() * 0.005) * delta * 0.4;
+  }
+
+  samplePositionAwayFromCamp(minDistance = 10, maxRadius = this.worldSize * 0.45) {
+    let attempts = 0;
+    while (attempts < 50) {
+      const angle = this.rng() * Math.PI * 2;
+      const radius = minDistance + this.rng() * (maxRadius - minDistance);
+      const x = Math.cos(angle) * radius;
+      const z = Math.sin(angle) * radius;
+      const y = this.getHeight(x, z);
+      if (Number.isFinite(y)) {
+        return new THREE.Vector3(x, y, z);
+      }
+      attempts += 1;
+    }
+    return new THREE.Vector3(0, this.getHeight(0, 0), 0);
+  }
+
+  placeResources(resourceManager) {
+    const resourceTypes = ['wood', 'stone', 'corn'];
+    const totalPerType = 15;
+    resourceTypes.forEach((type) => {
+      for (let i = 0; i < totalPerType; i += 1) {
+        const pos = this.samplePositionAwayFromCamp(12);
+        resourceManager.spawnResource(type, pos);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## What's Inside 🚀
- 🌲 Built a browser-playable, low-poly voxel camp explorer with seeded procedural terrain, camp setup, and cozy ambient lighting.
- 🎮 Implemented third-person player controller with WASD/drag look on desktop plus mobile-friendly joystick, look drag, and tap-to-collect support.
- 🪨 Added resource spawning/collection loop with compass hints toward the nearest needed cache, progress HUD, seed readout, and restartable win screen.
- 📄 Documented the project with contributor guidance in `AGENTS.md` and a refreshed `README.md` covering layout, controls, and setup.

## Testing 🧪
- ⚠️ Not run (browser game; launch via static server to verify).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff6df9864832ea0a2700a8d345bbd)