### PR TITLE
Improve mobile look controls and resource pickups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@
 
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
+## Version
+- Current release: **v0.2.0**
+- What's new in v0.2.0:
+  - Expanded mobile joystick activation and drag radius for smoother thumb control.
+  - Free-look camera drag on mobile (including vertical pitch) while idle, with character facing synced to camera.
+  - Larger resource pickup radius plus automatic collection when you brush past a node.
+
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.
-- Simple third-person character with WASD + drag-to-look controls; touch joystick and tap-to-collect for mobile.
+- Simple third-person character with WASD + drag-to-look controls; touch joystick and auto/tap-to-collect for mobile.
 - Sparse resources near camp to encourage exploration, plus a compass hint toward the nearest needed cache.
 - Lightweight assets (no build step); served via a single `index.html` + ES modules.
 
@@ -17,8 +24,8 @@ A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 
 2. Open `http://localhost:8080` (or your chosen port) in a modern browser.
 
 ## Controls
-- **Desktop:** WASD/arrow keys to move, drag the mouse to rotate, **E** to collect nearby resources.
-- **Mobile:** On-screen joystick to move, drag/right side to look, tap the **Collect** button or simply tap near a resource when close.
+- **Desktop:** WASD/arrow keys to move, drag the mouse to rotate (pitch and yaw), **E** to collect nearby resources.
+- **Mobile:** On-screen joystick (larger activation/drag area) to move, drag the right side to look freely even while idle, tap the **Collect** button or simply get close to a resource to auto-pickup.
 
 ## Project Layout
 - `index.html` – Canvas, HUD, mobile controls.

--- a/src/resources.js
+++ b/src/resources.js
@@ -46,24 +46,34 @@ export class ResourceManager {
   }
 
   tryCollect(player, interacted) {
+    const proximityNode = this.findClosestWithin(player.position, 1.4);
+    if (proximityNode) {
+      this.collectNode(proximityNode);
+      return true;
+    }
+
     if (!interacted && !this.autoCollectTouch(player)) return false;
-    const node = this.findClosestWithin(player.position, 2.4);
+    const node = this.findClosestWithin(player.position, 3.2);
     if (!node) return false;
-    const type = node.userData.type;
-    this.counters[type] += 1;
-    node.visible = false;
-    this.nodes = this.nodes.filter((n) => n !== node);
-    this.scene.remove(node);
+    this.collectNode(node);
     return true;
   }
 
   autoCollectTouch(player) {
     // Allow tap-to-collect on mobile when close enough
-    const node = this.findClosestWithin(player.position, 1.8);
+    const node = this.findClosestWithin(player.position, 2.6);
     if (node && this.world && window.matchMedia('(max-width: 900px)').matches) {
       return true;
     }
     return false;
+  }
+
+  collectNode(node) {
+    const type = node.userData.type;
+    this.counters[type] += 1;
+    node.visible = false;
+    this.nodes = this.nodes.filter((n) => n !== node);
+    this.scene.remove(node);
   }
 
   findClosestWithin(origin, maxDistance) {


### PR DESCRIPTION
## What's Inside ✨
- 📱 Broadened the mobile joystick activation zone and doubled its drag radius so thumb movement feels forgiving without losing clamped visuals.
- 🎥 Enabled right-side touch dragging to drive free-look (yaw and pitch) even while idle, keeping the character facing the camera direction for forward movement.
- 🪵 Increased collection radii, added proximity-based auto-pickup when brushing past resources, and consolidated the collect routine for consistency across inputs.
- 📖 Documented the v0.2.0 release in the README with control updates and a quick "what's new" rundown.

## Testing 🧪
- ⚠️ Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ffd6634c0832eaafe1ef4e3dab1b2)