### PR TITLE
Align player facing with camera drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 
 - What's new in v0.2.0:
   - Expanded mobile joystick activation and drag radius for smoother thumb control.
   - Free-look camera drag on mobile (including vertical pitch) while idle, with character facing synced to camera.
+  - Camera drags now immediately rotate the character's facing so joystick "forward" matches what you see.
   - Larger resource pickup radius plus automatic collection when you brush past a node.
 
 ## Features

--- a/src/player.js
+++ b/src/player.js
@@ -23,10 +23,11 @@ export class Player {
 
   update(delta, camera) {
     this.handleRotation(delta);
+    this.updateCamera(camera, delta);
+    this.alignToCamera(camera);
     this.handleMovement(delta);
     this.applyGroundSnap();
     this.mesh.position.copy(this.position);
-    this.updateCamera(camera, delta);
   }
 
   handleRotation(delta) {
@@ -65,5 +66,15 @@ export class Player {
     const desiredPos = this.position.clone().add(offset);
     camera.position.lerp(desiredPos, 1 - Math.pow(0.001, delta));
     camera.lookAt(this.position.clone().add(new THREE.Vector3(0, 1, 0)));
+  }
+
+  alignToCamera(camera) {
+    const toPlayer = this.position.clone().sub(camera.position);
+    toPlayer.y = 0;
+    if (toPlayer.lengthSq() > 0.0001) {
+      const cameraYaw = Math.atan2(toPlayer.x, toPlayer.z);
+      this.yaw = cameraYaw;
+      this.mesh.rotation.y = cameraYaw + Math.PI;
+    }
   }
 }


### PR DESCRIPTION
## What's Inside ✨
- 🔄 Synced the player’s yaw to the active camera heading so dragging to look on mobile now pivots the character, keeping joystick "forward" aligned with what you see.
- 📷 Added a camera-to-player alignment step that keeps movement vectors locked to the latest view direction for smoother relative motion.
- 📝 Updated the changelog notes to mention the improved camera drag facing behavior.

## Testing 🧪
- ❌ Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693000a79210832e9ec65dd869e9b9bb)