### PR TITLE
Improve camera orbit stability and view-based movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
 ## Version
-- Current release: **v0.2.2**
-- What's new in v0.2.2:
-  - Character facing now mirrors the camera's horizontal orientation, keeping forward movement aligned to your view.
-  - HUD now shows the build version alongside the session seed for quick verification.
+- Current release: **v0.2.3**
+- What's new in v0.2.3:
+  - Camera drag no longer jitters and fully orbits the player for smoother view control.
+  - Character facing now follows the camera heading so forward always means "toward the camera view".
+  - Default camera pitch sits slightly above the player to keep a slice of sky visible at start.
 
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { Input } from './input.js';
 import { ResourceManager } from './resources.js';
 import { UIOverlay } from './ui.js';
 
-const VERSION = 'v0.2.1';
+const VERSION = 'v0.2.3';
 
 const canvasContainer = document.body;
 

--- a/src/player.js
+++ b/src/player.js
@@ -8,10 +8,9 @@ export class Player {
     this.position = new THREE.Vector3(0, world.getHeight(0, 0) + 2.6, 0);
     this.velocity = new THREE.Vector3();
     this.speed = 16;
-    this.turnSpeed = 0.08;
     this.yaw = 0;
-    this.pitch = -0.35;
-    this.targetCameraOffset = new THREE.Vector3(0, 4.2, 8);
+    this.pitch = -0.28;
+    this.targetCameraOffset = new THREE.Vector3(0, 5, 10);
 
     const bodyGeo = new THREE.CapsuleGeometry(0.7, 1.4, 4, 8);
     const bodyMat = new THREE.MeshStandardMaterial({ color: '#f6e8c3', flatShading: true });
@@ -24,8 +23,8 @@ export class Player {
   update(delta, camera) {
     this.handleRotation(delta);
     this.updateCamera(camera, delta);
-    this.alignToCamera(camera);
     this.handleMovement(delta);
+    this.mesh.rotation.y = this.yaw + Math.PI;
     this.applyGroundSnap();
     this.mesh.position.copy(this.position);
   }
@@ -35,7 +34,6 @@ export class Player {
     this.yaw -= look.x * 0.003;
     this.pitch -= look.y * 0.003;
     this.pitch = Math.min(Math.max(this.pitch, -1.1), 0.2);
-    this.mesh.rotation.y = this.yaw + Math.PI;
   }
 
   handleMovement(delta) {
@@ -65,18 +63,6 @@ export class Player {
     offset.applyEuler(rot);
     const desiredPos = this.position.clone().add(offset);
     camera.position.lerp(desiredPos, 1 - Math.pow(0.001, delta));
-    camera.lookAt(this.position.clone().add(new THREE.Vector3(0, 1, 0)));
-  }
-
-  alignToCamera(camera) {
-    const forward = new THREE.Vector3();
-    camera.getWorldDirection(forward);
-    forward.y = 0;
-    if (forward.lengthSq() > 0.0001) {
-      forward.normalize();
-      const cameraYaw = Math.atan2(forward.x, forward.z);
-      this.yaw = cameraYaw;
-      this.mesh.rotation.y = cameraYaw + Math.PI;
-    }
+    camera.lookAt(this.position.clone().add(new THREE.Vector3(0, 1.2, 0)));
   }
 }


### PR DESCRIPTION
## What's Inside 🎁
- 🎥 Stabilized the third-person camera by removing jittery alignment logic so drag-to-look feels smooth across the full orbit.
- 🧭 Synced the character's facing and movement with the camera heading so forward input always follows the current view direction.
- 🌅 Raised the default camera offset and softened the pitch to start just above the player with a glimpse of the sky.
- 🏷️ Bumped the in-game version display and README to **v0.2.3** with updated release notes.

## Testing 🧪
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693009ceab64832e8d7c9a3ec241cf2c)