### PR TITLE
Fix mobile joystick direction and bump version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Favor readability over micro-optimizations; keep functions under ~60 lines when possible.
 - Update documentation (`README.md`) whenever you add or change features in the web game.
 - Keep UI text concise and friendly.
+- When changing the version, bump it in both the README and the on-screen display so they stay in sync.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
 ## Version
-- Current release: **v0.2.4**
-- What's new in v0.2.4:
-  - Forward, strafe, and facing now strictly follow the current camera heading for consistent input.
-  - Camera drag still orbits smoothly from just above the player with sky in frame.
+- Current release: **v0.2.5**
+- What's new in v0.2.5:
+  - Mobile joystick forward/back now matches the on-screen direction (up = forward, down = backward).
+  - Touch move clamp and drag visuals unchanged for smooth control feel.
 
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.

--- a/src/input.js
+++ b/src/input.js
@@ -87,7 +87,7 @@ export class Input {
       const maxDist = 80;
       const clamped = delta.clone().clampLength(0, maxDist);
       this.knob.style.transform = `translate(${clamped.x}px, ${clamped.y}px)`;
-      this.moveVector.set(clamped.x / maxDist, 0, -clamped.y / maxDist);
+      this.moveVector.set(clamped.x / maxDist, 0, clamped.y / maxDist);
     } else if (this.lookTouch && this.dragging) {
       const delta = current.clone().sub(this.lastPointer);
       this.lookDelta.add(delta);

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { Input } from './input.js';
 import { ResourceManager } from './resources.js';
 import { UIOverlay } from './ui.js';
 
-const VERSION = 'v0.2.4';
+const VERSION = 'v0.2.5';
 
 const canvasContainer = document.body;
 


### PR DESCRIPTION
## What's Inside 🎁
- 🚀 Corrected the mobile joystick so pushing up moves the character forward and pulling down walks backward, matching the on-screen cue.
- 🔢 Bumped the game version to **v0.2.5** in both the HUD and README to keep releases aligned.
- 📝 Added a reminder in `AGENTS.md` to always update both the README and on-screen version together.

## Testing 🧪
- ⚠️ Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300edb11e0832ea56f1c55daba9aaa)