### PR TITLE
Fix forward-facing auto-turn assist

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
 ## Version
-- Current release: **v0.3.1**
-- What's new in v0.3.1:
+- Current release: **v0.3.2**
+- What's new in v0.3.2:
+  - Gentle auto-turning now activates when moving forward within ±60° of your facing direction (instead of backward), making steering feel natural again.
   - Added touch-action and overscroll guards so the page no longer scrolls while dragging the mobile joystick.
-  - When moving within ±60° of the current facing direction, the camera and player gently yaw toward your movement so you can steer without pausing to drag.
 
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { Input } from './input.js';
 import { ResourceManager } from './resources.js';
 import { UIOverlay } from './ui.js';
 
-const VERSION = 'v0.3.1';
+const VERSION = 'v0.3.2';
 const BASE_MAP_SIZE = 140;
 
 const canvasContainer = document.body;

--- a/src/player.js
+++ b/src/player.js
@@ -62,7 +62,7 @@ export class Player {
   }
 
   gentlyTurnToward(direction) {
-    const desiredYaw = Math.atan2(direction.x, direction.z);
+    const desiredYaw = Math.atan2(-direction.x, -direction.z);
     const diff = this.normalizeAngle(desiredYaw - this.yaw);
     const maxAssist = Math.PI / 3;
     if (Math.abs(diff) > maxAssist) return;


### PR DESCRIPTION
## What's Inside
- 🧭 Fixed the gentle auto-turn to kick in when moving forward within the ±60° cone, so steering now nudges your facing direction instead of only while backpedaling.
- 🚶‍♂️ Kept the turn assist smooth with the existing easing while correcting the yaw target calculation.
- 📝 Bumped the in-game/README version to **v0.3.2** to document the forward auto-turn fix and keep displays in sync.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693019ee4a58832ea77ac2a552ec96af)