### PR TITLE
Fix mobile collect responsiveness and soften turning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
 ## Version
-- Current release: **v0.3.3**
-- What's new in v0.3.3:
-  - Softer assisted turning so slight left/right joystick nudges feel less dramatic.
-  - Collect button now brightens when you're close enough to interact and dims when you're out of range.
-  - Removed the nearest-cache readout for a cleaner HUD.
+- Current release: **v0.3.4**
+- What's new in v0.3.4:
+  - Collect button taps now register reliably as soon as the prompt lights up on touch devices.
+  - Directional turn assist is gentler so left/right nudges no longer cause wide arcs while moving forward.
 
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.

--- a/src/input.js
+++ b/src/input.js
@@ -70,8 +70,11 @@ export class Input {
     if (!this.isMobile) return;
     const touch = event.touches[0];
     if (!touch) return;
+    if (event.target === this.interactButton) {
+      this.queueInteract();
+      return;
+    }
     event.preventDefault();
-    if (event.target === this.interactButton) return;
 
     const leftZone = window.innerWidth * 0.7;
     const rect = this.joystick.getBoundingClientRect();

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { Input } from './input.js';
 import { ResourceManager } from './resources.js';
 import { UIOverlay } from './ui.js';
 
-const VERSION = 'v0.3.3';
+const VERSION = 'v0.3.4';
 const BASE_MAP_SIZE = 140;
 
 const canvasContainer = document.body;

--- a/src/player.js
+++ b/src/player.js
@@ -64,9 +64,9 @@ export class Player {
   gentlyTurnToward(direction) {
     const desiredYaw = Math.atan2(-direction.x, -direction.z);
     const diff = this.normalizeAngle(desiredYaw - this.yaw);
-    const maxAssist = Math.PI / 3;
+    const maxAssist = Math.PI / 5;
     if (Math.abs(diff) > maxAssist) return;
-    const turnRate = 0.03;
+    const turnRate = 0.012;
     this.yaw = this.normalizeAngle(this.yaw + diff * turnRate);
   }
 


### PR DESCRIPTION
# What's Inside ✨
- 📱 **Responsive Collect Button:** Touching the Collect prompt now immediately queues an interaction instead of being swallowed by the global touch handler, so pickups register the moment the button lights up.
- 🧭 **Gentler Turn Assist:** Forward movement steering now uses a smaller assist arc and turn rate, keeping left/right nudges subtle instead of swinging wide.
- 🗒️ **Version Bump:** Updated in-game/version notes to v0.3.4 to reflect the control tweaks and input fix.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693022a24be4832e919386e43c594302)