### PR TITLE
Add terrain height tuning and unify HUD corner styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A tiny low-poly voxel exploration demo built with Three.js. Collect 10 wood, 10 stone, and 10 corn around your camp with third-person controls that work on desktop and mobile.
 
 ## Version
-- Current release: **v0.3.6**
-- What's new in v0.3.6:
-  - Centralized map sizing, collection ranges, and steering assist tuning in one config for quicker balancing.
-  - Kept the control-hint chip pinned to the lower left so it stays visible without wrapping on mobile.
+- Current release: **v0.3.7**
+- What's new in v0.3.7:
+  - Added a terrain height multiplier to the tuning block so you can quickly dial in hilliness.
+  - Unified the HUD chip styling in every corner with matching rounded panels and pills.
 
 ## Features
 - Procedural terrain seeded per session, with the active seed shown in the corner.

--- a/index.html
+++ b/index.html
@@ -28,15 +28,18 @@
       flex-direction: column;
       justify-content: space-between;
       padding: 12px;
+      gap: 12px;
     }
-    #hud {
-      display: flex;
+    .panel {
+      display: inline-flex;
+      align-items: center;
       gap: 10px;
       font-size: 14px;
       padding: 6px 10px;
       background: rgba(0,0,0,0.35);
       border-radius: 8px;
       width: fit-content;
+      pointer-events: none;
     }
     .pill {
       display: inline-flex;
@@ -47,13 +50,13 @@
       background: rgba(255,255,255,0.08);
     }
     .legend { opacity: 0.8; font-size: 13px; }
-    #control-hint {
-      position: absolute;
-      left: 12px;
-      bottom: 12px;
-      white-space: nowrap;
-      pointer-events: none;
+    #bottom-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      width: 100%;
     }
+    #control-panel { align-items: center; }
     #seed {
       position: absolute;
       right: 8px;
@@ -151,13 +154,11 @@
       background: rgba(255,255,255,0.18);
       transform: translate(0,0);
     }
+    #action-panel { display: none; }
     #interact-btn {
-      position: absolute;
-      right: 24px;
-      bottom: 36px;
-      padding: 12px 16px;
-      border-radius: 12px;
-      background: rgba(255,255,255,0.14);
+      padding: 8px 14px;
+      border-radius: 999px;
+      background: rgba(255,255,255,0.12);
       color: #0b141a;
       font-weight: 700;
       border: none;
@@ -165,7 +166,8 @@
       pointer-events: auto;
       touch-action: manipulation;
       transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
-      opacity: 0.8;
+      opacity: 0.85;
+      box-shadow: 0 6px 18px rgba(0,0,0,0.28);
     }
     #interact-btn.ready {
       background: #3ecf8e;
@@ -179,6 +181,7 @@
     }
     @media (max-width: 900px) {
       #joystick, #interact-btn { display: block; }
+      #action-panel { display: inline-flex; }
       #hud { font-size: 13px; }
     }
   </style>
@@ -194,12 +197,19 @@
     </div>
   </div>
   <div id="ui">
-    <div id="hud">
+    <div id="hud" class="panel">
       <div class="pill">🌲 Wood: <span id="wood-count">0</span>/10</div>
       <div class="pill">🪨 Stone: <span id="stone-count">0</span>/10</div>
       <div class="pill">🌽 Corn: <span id="corn-count">0</span>/10</div>
     </div>
-    <div id="control-hint" class="pill legend">WASD/drag to move + look, E/tap to collect</div>
+    <div id="bottom-row">
+      <div id="control-panel" class="panel">
+        <div id="control-hint" class="pill legend">WASD/drag to move + look, E/tap to collect</div>
+      </div>
+      <div id="action-panel" class="panel">
+        <button id="interact-btn">Collect</button>
+      </div>
+    </div>
   </div>
   <div id="seed"></div>
   <div id="win">
@@ -208,7 +218,6 @@
     <button id="restart">Restart</button>
   </div>
   <div id="joystick"><div class="knob"></div></div>
-  <button id="interact-btn">Collect</button>
   <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -6,21 +6,29 @@ import { ResourceManager } from './resources.js';
 import { UIOverlay } from './ui.js';
 
 const GAME_TUNING = {
-  version: 'v0.3.6',
+  version: 'v0.3.7', // HUD/version label shown in-game
   map: {
-    baseSize: 140,
-    slider: { min: 1, max: 10, step: 1, default: 1 },
+    baseSize: 140, // Default map edge length in meters
+    slider: {
+      min: 1, // Minimum multiplier for map size
+      max: 10, // Maximum multiplier for map size
+      step: 1, // Step size for slider adjustments
+      default: 1, // Default multiplier on load
+    },
+  },
+  terrain: {
+    maxHeight: 6, // Peak terrain height multiplier for hills
   },
   collection: {
-    proximityCollectRange: 1.4,
-    interactCollectRange: 9.6,
-    touchAutoCollectRange: 7.8,
-    interactButtonRange: 3.2,
+    proximityCollectRange: 1.4, // Auto-collect radius when extremely close
+    interactCollectRange: 9.6, // Maximum reach for manual collect checks
+    touchAutoCollectRange: 7.8, // Mobile auto-collect bubble when moving past
+    interactButtonRange: 3.2, // Range threshold for enabling the Collect button
   },
   turnAssist: {
-    arcRadians: Math.PI / 5,
-    strengthScale: 5,
-    strengthMax: 0.18,
+    arcRadians: Math.PI / 5, // Aim cone angle for steering assistance
+    strengthScale: 5, // Multiplier applied to assist strength
+    strengthMax: 0.18, // Upper clamp for turn assist influence
   },
 };
 
@@ -68,7 +76,7 @@ class Game {
     this.scene = createScene();
     this.renderer = createRenderer();
     this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 500);
-    this.world = new World(this.seed, { mapSize });
+    this.world = new World(this.seed, { mapSize, heightScale: this.tuning.terrain.maxHeight });
     this.tuning = GAME_TUNING;
     this.input = new Input(this.renderer.domElement, this.tuning.collection);
     this.player = new Player(this.world, this.input, this.tuning.turnAssist);

--- a/src/world.js
+++ b/src/world.js
@@ -23,12 +23,12 @@ function lerp(a, b, t) {
 }
 
 export class World {
-  constructor(seed, { mapSize } = {}) {
+  constructor(seed, { mapSize, heightScale } = {}) {
     this.seed = seed;
     this.worldSize = mapSize ?? 140;
     this.gridResolution = 96;
     this.heightMap = [];
-    this.heightScale = 6;
+    this.heightScale = heightScale ?? 6;
     this.noiseScale = 14;
     this.rng = mulberry32(hashString(seed));
     this.mesh = this.buildTerrain();
@@ -61,7 +61,7 @@ export class World {
 
   getHeight(x, z) {
     const base = this.noise(x + 50, z + 50) * this.heightScale;
-    const detail = this.noise(x * 2.5 + 100, z * 2.5 + 100) * 1.5;
+    const detail = this.noise(x * 2.5 + 100, z * 2.5 + 100) * (this.heightScale * 0.25);
     return base + detail;
   }
 


### PR DESCRIPTION
## What’s Inside 🌟
- 🌄 Added a new terrain height multiplier in the main tuning block so hills can be dialed up or down without diving into world code.
- 📝 Documented every tuning constant with inline comments and bumped the game version display + README to v0.3.7.
- 🎛️ Wired the World generator to respect the new height setting, keeping detail noise proportional to the chosen peak height.
- 🎨 Standardized the HUD corners with matching rounded panels and chips, bringing the lower-left hint and lower-right Collect button in line with the top-left style.

## Testing 🧪
- ⚠️ Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312b7a7bb4832eaa7bd3cf9cdb986a)